### PR TITLE
Network abstractions

### DIFF
--- a/actions/evergreen/index.ts
+++ b/actions/evergreen/index.ts
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './run.js';
 export * from './actions.js';
+export * from './evergreen_spec.js';
 export * from './interfaces.js';
+export {
+  AbstractBaseConnectionManager,
+  CachingConnectionManagerFactory,
+} from './net.js';
+export type {ConnectionManager, SessionMessageCallbackFn} from './net.js';
+export * from './run.js';

--- a/actions/evergreen/net.ts
+++ b/actions/evergreen/net.ts
@@ -1,0 +1,341 @@
+/**
+ * @fileoverview Abstractions for the network layer required to execute
+ * Evergreen actions on remote servers from a web browser client. As well as
+ * a default implementation that uses WebSockets for network transport.
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Session} from '../../interfaces.js';
+
+import * as eg from './evergreen_spec.js';
+
+/**
+ * Interface for callback functions that are invoked by the
+ * `ConnectionManager` when a `SessionMessage` is received from the remote
+ * server.
+ */
+export declare interface SessionMessageCallbackFn {
+  (message: eg.SessionMessage): void;
+}
+
+/**
+ * `ConnectionManager` is the interface between Evergreen action execution
+ * methods defined in `run.ts` and the network transport used to communicate
+ * with the remote server. `T` is the type of response message expected from
+ * the remote server.
+ */
+export declare interface ConnectionManager<T> {
+  /**
+   * Registers a `SesionMessageCallbackFn` to be invoked when a `SessionMessage`
+   * is received from the remote server. If multiple callbacks are registered
+   * then they will each be invoked for each `SessionMessage` received.
+   */
+  registerSessionMessageCallback(callback: SessionMessageCallbackFn): void;
+
+  /**
+   * Establish a connection to the remote server. This is a no-op if the
+   * connection is already established.
+   */
+  connect(): Promise<void>;
+
+  /**
+   * End the connection to the remote server. This is a no-op if the connection
+   * is already closed or was never established.
+   */
+  disconnect(): void;
+
+  /**
+   * Send a message to the remote server.
+   */
+  send(message: eg.SessionMessage): void;
+
+  /**
+   * Callback that is invoked when a response is received from the
+   * remote server. Note that implementers of this interface must ensure
+   * that this callback is invoked e.g. by registering an event listener
+   * on the underlying network connection.
+   */
+  onServerResponse(message: T): Promise<void>;
+
+  /**
+   * Callback that is invoked when an error is received from the remote server.
+   * Note that implementers of this interface must ensure that this callback is
+   * invoked e.g. by registering an event listener on the underlying network
+   * connection.
+   */
+  onError(event: any): void;
+
+  /**
+   * Callback that is invoked when the connection is closed. Note that
+   * implementers of this interface must ensure that this callback is invoked
+   * e.g. by registering an event listener on the underlying network connection.
+   */
+  onClose(event: any): void;
+
+  /**
+   * Returns `true` if the connection is considered "valid" and `false`
+   * otherwise. The exact semantics of valid and invalid are up to the
+   * interface implementer. A connection which is invalid will be disposed
+   * of and a new connection will be created to replace it.
+   */
+  isValidConnection(): boolean;
+}
+
+/**
+ * Abstract base implementation of the `ConnectionManager` interface. This
+ * base class provides a default implementation of the `onServerResponse`
+ * method. The default implementation converts the raw server response into
+ * a `SessionMessage` object and notifies any registered callbacks of the newly
+ * available `SessionMessage`. Implementers must provide their own concrete
+ * implementation of the `convertServerResponseToSessionMessage` method which
+ * performs the conversion from the raw server response to a `SessionMessage`
+ * object.
+ */
+export abstract class AbstractBaseConnectionManager<T>
+  implements ConnectionManager<T>
+{
+  private callbacks: SessionMessageCallbackFn[] = [];
+
+  /**
+   * Method defined in interface. Registers the provided `callback` in an
+   * internal array of callbacks. Each callback will be invoked when a new
+   * `SessionMessage` is received from the remote server.
+   */
+  registerSessionMessageCallback(callback: SessionMessageCallbackFn): void {
+    this.callbacks.push(callback);
+  }
+
+  /**
+   * Method defined in interface. Implementers must override this method with
+   * a concrete implementation. Refer to interface documentation for more
+   * details.
+   */
+  abstract connect(): Promise<void>;
+
+  /**
+   * Method defined in interface. Implementers must override this method with
+   * a concrete implementation. Refer to interface documentation for more
+   * details.
+   */
+  abstract disconnect(): void;
+
+  /**
+   * Method defined in interface. Implementers must override this method with
+   * a concrete implementation. Refer to interface documentation for more
+   * details.
+   */
+  abstract send(message: eg.SessionMessage): void;
+
+  /**
+   * Method defined in interface. Implementers must override this method with
+   * a concrete implementation. Refer to interface documentation for more
+   * details.
+   */
+  abstract onError(event: any): void;
+
+  /**
+   * Method defined in interface. Implementers must override this method with
+   * a concrete implementation. Refer to interface documentation for more
+   * details.
+   */
+  abstract onClose(event: any): void;
+
+  /**
+   * Method defined in interface. Implementers must override this method with
+   * a concrete implementation. Refer to interface documentation for more
+   * details.
+   */
+  abstract isValidConnection(): boolean;
+
+  /**
+   * Default implementation of the `onServerResponse` method. This method
+   * converts the raw server response into a `SessionMessage` object and emits
+   * it via the registered callbacks. Implementers must provide their
+   * own concrete implementation of the `convertServerResponseToSessionMessage`
+   * method below.
+   */
+  async onServerResponse(event: T): Promise<void> {
+    const message: eg.SessionMessage | undefined =
+      await this.convertServerResponseToSessionMessage(event);
+    if (message) {
+      for (const callback of this.callbacks) {
+        callback(message);
+      }
+    }
+  }
+
+  /**
+   * Converts the raw server response into a `SessionMessage` object. If the
+   * response does not represent a valid `SessionMessage` then either an
+   * error should be raised or `undefined` should be returned. If the response
+   * is expected but simply doesn't represent a `SessionMessage`, e.g. the
+   * response represents some network control metadata, then the appropriate
+   * behavior is to return `undefined`. However, if the response is not
+   * expected and represents an error, then an error should be raised.
+   */
+  protected abstract convertServerResponseToSessionMessage(
+    event: T,
+  ): Promise<eg.SessionMessage | undefined>;
+}
+
+/**
+ * Function that instantiates new `WebSocketConnectionManager`s. This is
+ * intended to be used as the `createManagerFn` argument to the
+ * `CachingConnectionManagerFactory` constructor.
+ */
+export function WebSocketConnectionManagerFactoryFn(
+  backendUrl: string,
+): WebSocketConnectionManager {
+  return WebSocketConnectionManager.createWithUrl(backendUrl);
+}
+
+/**
+ * Implementation of the `ConnectionManager` interface that uses WebSockets
+ * for network transport.
+ */
+export class WebSocketConnectionManager extends AbstractBaseConnectionManager<MessageEvent> {
+  private readonly socket: WebSocket;
+
+  private constructor(backendUrl?: string, socket?: WebSocket) {
+    super();
+    if (backendUrl) {
+      this.socket = new WebSocket(backendUrl);
+    } else if (socket) {
+      this.socket = socket;
+    } else {
+      throw new Error('Either backendUrl or socket must be provided.');
+    }
+    this.socket.binaryType = 'blob';
+  }
+
+  static createWithUrl(backendUrl: string): WebSocketConnectionManager {
+    return new WebSocketConnectionManager(backendUrl);
+  }
+
+  static createWithSocket(socket: WebSocket): WebSocketConnectionManager {
+    return new WebSocketConnectionManager(undefined, socket);
+  }
+
+  override isValidConnection(): boolean {
+    return this.socket.readyState === WebSocket.OPEN;
+  }
+
+  override async connect(): Promise<void> {
+    if (this.isValidConnection()) {
+      console.info('WebSocket already connected');
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      this.socket.addEventListener('open', () => {
+        this.socket.removeEventListener('error', reject);
+        this.socket.removeEventListener('close', reject);
+        resolve();
+      });
+      this.socket.addEventListener('error', reject);
+      this.socket.addEventListener('close', reject);
+    });
+    this.socket.onmessage = async (event: MessageEvent) => {
+      await this.onServerResponse(event);
+    };
+    this.socket.onerror = (event: any) => {
+      this.onError(event);
+    };
+    this.socket.onclose = (event: any) => {
+      this.onClose(event);
+    };
+  }
+
+  override disconnect(): void {
+    // TODO(geoffdowns): not in original implementation. Remove? Retain?
+    this.socket.close();
+  }
+
+  override send(message: eg.SessionMessage): void {
+    this.socket.send(JSON.stringify(message));
+  }
+
+  override async convertServerResponseToSessionMessage(
+    event: MessageEvent,
+  ): Promise<eg.SessionMessage | undefined> {
+    let message: eg.SessionMessage;
+    switch (event.type) {
+      case 'text':
+      case 'message':
+      case 'binary':
+        const data = event.data as unknown;
+        if (data instanceof Blob) {
+          const buf = await data.arrayBuffer();
+          message = JSON.parse(
+            new TextDecoder().decode(new Uint8Array(buf)),
+          ) as eg.SessionMessage;
+        } else if (data instanceof ArrayBuffer) {
+          message = JSON.parse(
+            new TextDecoder().decode(new Uint8Array(data)),
+          ) as eg.SessionMessage;
+        } else if (typeof data === 'string') {
+          message = JSON.parse(data) as eg.SessionMessage;
+        } else {
+          throw new Error(
+            `Unsupported type ${this.socket.binaryType} ${typeof data}`,
+          );
+        }
+        break;
+      default:
+        throw new Error(`Unknown message type ${event.type}`);
+    }
+    return message;
+  }
+
+  override onError(event: any) {
+    console.info('Websocket error', event, this.socket);
+  }
+
+  override onClose(event: any) {
+    // See
+    // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code#value
+    // for mapping from code to explanation.
+    console.info(
+      `Websocket closed: ${event.reason} ${event.code}`,
+      event,
+      this.socket,
+    );
+  }
+}
+
+/**
+ * Factory for creating `ConnectionManager`s. This factory caches
+ * `ConnectionManager`s for a given `Session`. Previously cached
+ * `ConnectionManager`s are only returned if they are considered "valid".
+ * Implementers of the `ConnectionManager` interface must define what it means
+ * for a connection to be valid or invalid. Typically this will be based on
+ * the state of the underlying network connection, e.g. a `WebSocket` in the
+ * `WebSocket.OPEN` state would be considered valid and all other states would
+ * be considered invalid.
+ */
+export class CachingConnectionManagerFactory<T> {
+  private readonly connectionMap = new Map<Session, ConnectionManager<T>>();
+  private readonly createManagerFn: (
+    backendUrl: string,
+  ) => ConnectionManager<T>;
+
+  constructor(createManagerFn: (backendUrl: string) => ConnectionManager<T>) {
+    this.createManagerFn = createManagerFn;
+  }
+
+  getConnection(session: Session, backendUrl: string): ConnectionManager<T> {
+    let manager = this.connectionMap.get(session);
+    if (manager) {
+      if (manager.isValidConnection()) {
+        return manager;
+      } else {
+        manager = undefined;
+        this.connectionMap.delete(session);
+      }
+    }
+
+    manager = this.createManagerFn(backendUrl);
+    this.connectionMap.set(session, manager);
+    return manager;
+  }
+}

--- a/actions/evergreen/net_test.ts
+++ b/actions/evergreen/net_test.ts
@@ -1,0 +1,262 @@
+import 'jasmine';
+
+import {encode as b64encode} from '../../base64/index.js';
+//import * as content from '../../content/index.js';
+import * as eg from './evergreen_spec.js';
+import {WebSocketConnectionManager} from './net.js';
+import {FakeWebSocket} from './test_utils.js';
+
+class TestSessionMessageCallback {
+  capturedSessionMessages: eg.SessionMessage[] = [];
+
+  callback(message: eg.SessionMessage): void {
+    this.capturedSessionMessages.push(message);
+  }
+}
+
+describe('WebSocketConnectionManager Test', () => {
+  let fakeWebSocket: FakeWebSocket;
+  let testCallback: TestSessionMessageCallback;
+  let impl: WebSocketConnectionManager;
+  const closeMsg: eg.SessionMessage = {
+    nodeFragments: [
+      {
+        id: 'close',
+        seq: 0,
+        continued: false,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    // We need to define WebSocket in the global scope because the
+    // test environment, unlike a browser runtime environment, does not
+    // define this class.
+    globalThis.WebSocket = FakeWebSocket;
+    fakeWebSocket = new FakeWebSocket('wss://test');
+    impl = WebSocketConnectionManager.createWithSocket(fakeWebSocket);
+
+    // register a callback to capture any session messages received
+    testCallback = new TestSessionMessageCallback();
+    impl.registerSessionMessageCallback((message: eg.SessionMessage) => {
+      testCallback.callback(message);
+    });
+  });
+
+  it('Error during connect', async () => {
+    const p = impl.connect();
+    // trigger an error event on the fake web socket
+    const errorEvent = new Event('error') as WebSocketEventMap['error'] & {
+      type: 'error';
+    };
+    fakeWebSocket.dispatchEvent(errorEvent);
+    await expectAsync(p).toBeRejected();
+  });
+
+  it('Socket closed during connect', async () => {
+    const p = impl.connect();
+    // trigger a close event on the fake web socket
+    const closeEvent = new Event('close') as WebSocketEventMap['close'] & {
+      type: 'close';
+    };
+    fakeWebSocket.dispatchEvent(closeEvent);
+    await expectAsync(p).toBeRejected();
+  });
+
+  it('Successful connection', async () => {
+    const p = impl.connect();
+    // trigger a open event on the fake web socket
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent(openEvent);
+    await expectAsync(p).toBeResolved();
+
+    // expect the 'isValidConnection' method to return true
+    expect(impl.isValidConnection()).toBeTrue();
+  });
+
+  it('Send method passes expected payload to socket', async () => {
+    // Connect the websocket
+    const p = impl.connect();
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent(openEvent);
+    await expectAsync(p).toBeResolved();
+
+    // Send a SessionMessage
+    const sessionMessage: eg.SessionMessage = {
+      nodeFragments: [
+        {
+          id: 'test',
+          seq: 0,
+          continued: false,
+          chunkFragment: {
+            metadata: {
+              mimetype: 'text/plain',
+              role: 'user',
+            },
+            data: b64encode(new TextEncoder().encode('this is a test')),
+          },
+        },
+      ],
+    };
+    impl.send(sessionMessage);
+
+    // Expect the fake websocket 'send' method to have been invoked with the
+    // SessionMessage as json serialized string.
+    expect(fakeWebSocket.sentMessages).toEqual(
+      jasmine.arrayWithExactContents([JSON.stringify(sessionMessage)]),
+    );
+  });
+
+  interface ValidServerResponseTestCase {
+    description: string;
+    eventType: string;
+    transform: (message: eg.SessionMessage) => any;
+  }
+
+  const testCases: ValidServerResponseTestCase[] = [
+    {
+      description: 'when provided as string',
+      eventType: 'text',
+      transform: JSON.stringify,
+    },
+    {
+      description: 'when provided as ArrayBuffer',
+      eventType: 'text',
+      transform: (message: eg.SessionMessage) => {
+        const encodedArray = new TextEncoder().encode(JSON.stringify(message));
+        return encodedArray.buffer.slice(
+          encodedArray.byteOffset,
+          encodedArray.byteOffset + encodedArray.byteLength,
+        );
+      },
+    },
+    {
+      description: 'when provided as Blob',
+      eventType: 'binary',
+      transform: (message: eg.SessionMessage) => {
+        const encodedArray = new TextEncoder().encode(JSON.stringify(message));
+        return new Blob([encodedArray], {
+          type: 'application/octet-stream',
+        });
+      },
+    },
+  ];
+
+  // Execute each of the test cases defined above. The setup and expectations
+  // for these tests are identical, so we use a parameterized test to avoid
+  // copy/paste. The difference between these test cases is the specific
+  // format of the MessageEvent.data field in our simulated server response.
+  testCases.forEach(({description, eventType, transform}) => {
+    it(`Correctly parses server response ${description}`, async () => {
+      // Connect the websocket
+      const p = impl.connect();
+      const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+        type: 'open';
+      };
+      fakeWebSocket.dispatchEvent(openEvent);
+      await expectAsync(p).toBeResolved();
+
+      // configure the fake websocket to invoke the onmessage handler with
+      // a MessageEvent that contains a SessionMessage as a JSON string.
+      const sessionMessage: eg.SessionMessage = {
+        nodeFragments: [
+          {
+            id: 'test',
+            seq: 0,
+            continued: false,
+            chunkFragment: {
+              metadata: {
+                mimetype: 'text/plain',
+                role: 'model',
+              },
+              data: b64encode(new TextEncoder().encode('this is a test')),
+            },
+          },
+        ],
+      };
+      const serverResponse = new MessageEvent(eventType, {
+        data: transform(sessionMessage),
+      });
+      fakeWebSocket.responses.push(serverResponse);
+
+      // Send a close message to the websocket to trigger the server response
+      // being sent.
+      impl.send(closeMsg);
+
+      // Wait for the onMessageCompletePromise to resolve.
+      await fakeWebSocket.onMessageCompletePromise;
+
+      // verify the callback was invoked with the expected SessionMessage
+      expect(testCallback.capturedSessionMessages).toEqual(
+        jasmine.arrayWithExactContents([sessionMessage]),
+      );
+    });
+  });
+
+  it('Raises error when data in server response is not a supported type', async () => {
+    // Connect the websocket
+    const p = impl.connect();
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent(openEvent);
+    await expectAsync(p).toBeResolved();
+
+    // send a server response with a data field that is not a supported type
+    const sessionMessage: eg.SessionMessage = {
+      nodeFragments: [
+        {
+          id: 'test',
+          seq: 0,
+          continued: false,
+          chunkFragment: {
+            metadata: {
+              mimetype: 'text/plain',
+              role: 'model',
+            },
+            data: b64encode(new TextEncoder().encode('this is a test')),
+          },
+        },
+      ],
+    };
+    const serverResponse = new MessageEvent('other', {
+      data: JSON.stringify(sessionMessage),
+    });
+    fakeWebSocket.responses.push(serverResponse);
+
+    // Send a close message to the websocket to trigger the server response
+    // being sent.
+    impl.send(closeMsg);
+    await expectAsync(
+      fakeWebSocket.onMessageCompletePromise,
+    ).toBeRejectedWithError();
+  });
+
+  it('Raises error when server response is not a supported event type', async () => {
+    // Connect the websocket
+    const p = impl.connect();
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent(openEvent);
+    await expectAsync(p).toBeResolved();
+
+    // send a server response with a valid data field but an unsupported
+    // event type
+    const serverResponse = new MessageEvent('other', {
+      data: [1, 2, 3],
+    });
+    fakeWebSocket.responses.push(serverResponse);
+
+    // Send a close message to the websocket to trigger the server response
+    // being sent.
+    impl.send(closeMsg);
+    await expectAsync(
+      fakeWebSocket.onMessageCompletePromise,
+    ).toBeRejectedWithError();
+  });
+});

--- a/actions/evergreen/run_test.ts
+++ b/actions/evergreen/run_test.ts
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview Index export.
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {encode as b64encode} from '../../base64/index.js';
+import * as content from '../../content/index.js';
+import {Session} from '../../interfaces.js';
+import {local} from '../../sessions/local.js';
+import {ActionSchema} from './interfaces.js';
+import {
+  CachingConnectionManagerFactory,
+  WebSocketConnectionManager,
+} from './net.js';
+import {action, Options, StreamIdGenerator} from './run.js';
+import {FakeWebSocket} from './test_utils.js';
+
+import 'jasmine';
+
+class SimpleTestAction implements ActionSchema {
+  name = 'simple_test_action';
+  inputs = [
+    {
+      name: 'prompt',
+      description: 'the prompt',
+      type: [{type: 'text', subtype: 'plain'}],
+    },
+  ];
+  outputs = [
+    {
+      name: 'result',
+      description: 'the result',
+      type: [{type: 'text', subtype: 'plain'}],
+    },
+  ];
+}
+
+class FakeStreamIdGenerator implements StreamIdGenerator {
+  generateStreamId(streamName: string): string {
+    return streamName;
+  }
+}
+
+describe('EvergreenAction', () => {
+  let session: Session;
+  let fakeWebSocket: FakeWebSocket;
+  let connManagerFactory: CachingConnectionManagerFactory<MessageEvent>;
+  let options: Options;
+
+  beforeEach(() => {
+    // We need to define WebSocket in the global scope because the
+    // test environment, unlike a browser runtime environment, does not
+    // define this class.
+    globalThis.WebSocket = FakeWebSocket;
+
+    session = local();
+    fakeWebSocket = new FakeWebSocket('wss://test');
+    connManagerFactory = new CachingConnectionManagerFactory(
+      (backendUrl: string) => {
+        return WebSocketConnectionManager.createWithSocket(fakeWebSocket);
+      },
+    );
+    options = new Options(
+      'evergreen://localhost',
+      new FakeStreamIdGenerator(),
+      connManagerFactory,
+    );
+  });
+
+  it('run handles error from remote server on sendAction', async () => {
+    // create the EvergreenAction object
+    const impl = action(
+      'evergreen://localhost',
+      new SimpleTestAction(),
+      options,
+    );
+
+    // call run, don't await
+    const userPrompt = session.createPipe();
+    void userPrompt.writeAndClose(content.prompt`test prompt`);
+    const inputs = {prompt: userPrompt};
+    const outputs = {result: session.createPipe()};
+    impl.run(session, inputs, outputs);
+
+    // simulate a successful websocket connection
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent<'open'>(openEvent);
+
+    // trying to read the output should not return any value
+    const asyncIterator = outputs.result[Symbol.asyncIterator]();
+    const resultCheck = await Promise.race([
+      asyncIterator.next(),
+      new Promise<boolean>((resolve) => {
+        setTimeout(() => {
+          resolve(true);
+        }, 100);
+      }),
+    ]);
+    expect(resultCheck).toBeTrue();
+
+    // verify the `send` message was invoked. Note that, even though we only
+    // called 'run' once and only provided a single input, the websocket
+    // `send` method is typically invoked multiple times.
+    expect(fakeWebSocket.sentMessages.length).toBeGreaterThan(0);
+  });
+
+  it('successful response populates the output stream', async () => {
+    // set the expected response
+    const event = new MessageEvent('text', {
+      data: JSON.stringify({
+        nodeFragments: [
+          {
+            id: 'result',
+            seq: 0,
+            continued: false,
+            chunkFragment: {
+              metadata: {
+                mimetype: 'text/plain',
+                role: 'model',
+              },
+              data: b64encode(new TextEncoder().encode('test response')),
+            },
+          },
+        ],
+      }),
+    });
+    fakeWebSocket.responses.push(event);
+
+    // create the EvergreenAction object
+    const impl = action(
+      'evergreen://localhost',
+      new SimpleTestAction(),
+      options,
+    );
+
+    // call run but don't await
+    const userPrompt = session.createPipe();
+    void userPrompt.writeAndClose(content.prompt`test prompt`);
+    const inputs = {prompt: userPrompt};
+    const outputs = {result: session.createPipe()};
+    impl.run(session, inputs, outputs);
+
+    // simulate a successful websocket connection
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent<'open'>(openEvent);
+
+    // get the response from the output stream
+    const asyncIterator = outputs.result[Symbol.asyncIterator]();
+    const result = await asyncIterator.next();
+    expect(content.isTextChunk(result.value)).toBeTrue();
+    expect(content.chunkText(result.value)).toEqual('test response');
+  });
+
+  it('handles response with content in child node', async () => {
+    // set the expected responses
+    const parentEvent = new MessageEvent('text', {
+      data: JSON.stringify({
+        nodeFragments: [
+          {
+            id: 'result',
+            seq: 0,
+            continued: true,
+            childIds: ['child'],
+          },
+        ],
+      }),
+    });
+    const childEvent = new MessageEvent('text', {
+      data: JSON.stringify({
+        nodeFragments: [
+          {
+            id: 'child',
+            seq: 0,
+            continued: false,
+            chunkFragment: {
+              metadata: {
+                mimetype: 'text/plain',
+                role: 'model',
+              },
+              data: b64encode(new TextEncoder().encode('test response')),
+            },
+          },
+        ],
+      }),
+    });
+    const finalEvent = new MessageEvent('text', {
+      data: JSON.stringify({
+        nodeFragments: [
+          {
+            id: 'result',
+            seq: 1,
+            continued: false,
+          },
+        ],
+      }),
+    });
+    fakeWebSocket.responses = [parentEvent, childEvent, finalEvent];
+
+    // create the EvergreenAction object
+    const impl = action(
+      'evergreen://localhost',
+      new SimpleTestAction(),
+      options,
+    );
+
+    // call run but don't await
+    const userPrompt = session.createPipe();
+    void userPrompt.writeAndClose(content.prompt`test prompt`);
+    const inputs = {prompt: userPrompt};
+    const outputs = {result: session.createPipe()};
+    impl.run(session, inputs, outputs);
+
+    // simulate a successful websocket connection
+    const openEvent = new Event('open') as WebSocketEventMap['open'] & {
+      type: 'open';
+    };
+    fakeWebSocket.dispatchEvent<'open'>(openEvent);
+
+    // get the response from the output stream
+    const asyncIterator = outputs.result[Symbol.asyncIterator]();
+    const result = await asyncIterator.next();
+    expect(content.isTextChunk(result.value)).toBeTrue();
+    expect(content.chunkText(result.value)).toEqual('test response');
+  });
+});

--- a/actions/evergreen/test_utils.ts
+++ b/actions/evergreen/test_utils.ts
@@ -1,0 +1,163 @@
+/**
+ * @fileoverview Test utilities for this package.
+ */
+
+import {SessionMessage} from './evergreen_spec.js';
+
+/**
+ * A fake implementation of the `WebSocket` class for testing purposes.
+ */
+export class FakeWebSocket {
+  // Unused but required by the interface.
+  url = '';
+
+  // Record of all the payloads provided to invocations of the `send` method.
+  sentMessages: string[] = [];
+
+  // Set `responses` if you want to simulate one or more responses from the
+  // server. The response will only be sent once the `send` method is invoked
+  // with a "close message". A close message is one where the only
+  // "nodeFragment" has `continued` set to false.
+  // If no response is set, then any invocation of `send` will result in
+  // the `onerror` handler being called instead.
+  responses: MessageEvent[] = [];
+
+  private isCloseMessage(message: string): boolean {
+    const parsedMsg = JSON.parse(message) as SessionMessage;
+    return (
+      parsedMsg.nodeFragments?.length === 1 &&
+      !parsedMsg.nodeFragments[0].continued
+    );
+  }
+
+  onopen: ((event: Event) => void) | null = null;
+
+  onclose(event: CloseEvent) {}
+
+  onerror(event: Event) {}
+
+  onmessage(event: MessageEvent): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Promise that resolves when any and all async methods invoked as a
+   * result of calling the `send` method have completed. In this fake
+   * implementation, we use the special "close" SessionMessage as a signal
+   * that all server responses registered via `responses` should be sent.
+   * Handling server responses is an async operation. So waiting on this
+   * promise enables tests to wait until all server responses have been
+   * handled before proceeding.
+   */
+  onMessageCompletePromise: Promise<void> | null = null;
+
+  send(data: any) {
+    this.sentMessages.push(data as string);
+    if (this.isCloseMessage(data as string)) {
+      // 'Send' isn't async but we have overridden the behavior so that a
+      // close message triggers a simulated "response" from the server. The
+      // server response is simulated by calling the onmessage handler. And
+      // the onmessage handler is async. We expose the promise that results
+      // from the onmessage function call so that tests can wait for the
+      // response to be handled before proceeding.
+      const promises: Array<Promise<void>> = [];
+      for (const response of this.responses) {
+        promises.push(this.onmessage(response));
+      }
+      this.onMessageCompletePromise = Promise.all(promises).then(() => {});
+    }
+  }
+
+  close() {
+    this.onclose({} as CloseEvent);
+  }
+
+  addEventListener<K extends keyof WebSocketEventMap>(
+    type: K,
+    listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    switch (type) {
+      case 'open':
+        this.onopen = listener as (this: WebSocket, ev: Event) => any;
+        break;
+      case 'close':
+        this.onclose = listener as (this: WebSocket, ev: CloseEvent) => any;
+        break;
+      case 'error':
+        this.onerror = listener as (this: WebSocket, ev: Event) => any;
+        break;
+      case 'message':
+        this.onmessage = listener as (this: WebSocket, ev: MessageEvent) => any;
+        break;
+      default:
+        break;
+    }
+  }
+  removeEventListener<K extends keyof WebSocketEventMap>(
+    type: K,
+    listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    switch (type) {
+      case 'open':
+        this.onopen = null;
+        break;
+      case 'close':
+        this.onclose = (event: CloseEvent) => {};
+        break;
+      case 'error':
+        this.onerror = (event: Event) => {};
+        break;
+      case 'message':
+        this.onmessage = (event: MessageEvent): Promise<void> => {
+          return Promise.resolve();
+        };
+        break;
+      default:
+        break;
+    }
+  }
+  dispatchEvent<K extends keyof WebSocketEventMap>(
+    event: WebSocketEventMap[K] & {type: K},
+  ): boolean {
+    switch (event.type) {
+      case 'open':
+        this.readyState = FakeWebSocket.OPEN;
+        this.onopen?.call(this, event);
+        break;
+      case 'close':
+        this.readyState = FakeWebSocket.CLOSED;
+        this.onclose.call(this, event as CloseEvent);
+        break;
+      case 'error':
+        this.readyState = FakeWebSocket.CLOSED;
+        this.onerror.call(this, event);
+        break;
+      case 'message':
+        this.onmessage.call(this, event as MessageEvent);
+        break;
+      default:
+        break;
+    }
+    return true;
+  }
+
+  // Required by the interface but has no effect in this fake implementation.
+  constructor(url: string | URL, protocols?: string | string[] | undefined) {}
+
+  binaryType: BinaryType = 'blob';
+
+  static readonly CONNECTING: typeof WebSocket.CONNECTING = 0;
+  static readonly OPEN: typeof WebSocket.OPEN = 1;
+  static readonly CLOSING: typeof WebSocket.CLOSING = 2;
+  static readonly CLOSED: typeof WebSocket.CLOSED = 3;
+  CONNECTING: typeof WebSocket.CONNECTING = 0;
+  OPEN: typeof WebSocket.OPEN = 1;
+  CLOSING: typeof WebSocket.CLOSING = 2;
+  CLOSED: typeof WebSocket.CLOSED = 3;
+  readyState = 0;
+  bufferedAmount = 0;
+  extensions = '';
+  protocol = '';
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "@google/genai": "^0.2.0",
-    "blob-polyfill": "^9.0.20240710"
+    "blob-polyfill": "^9.0.20240710",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@material/web": "^2.2.0",
@@ -35,7 +36,7 @@
     "@types/node": "^22.7.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
-    "@types/ws": "^8.18.1",
+    "@types/tailwindcss": "^3.0.11",
     "concurrently": "^9.0.1",
     "esbuild": ">=0.25.0",
     "eslint": "^9.19.0",
@@ -48,8 +49,8 @@
     "react-dom": "^19.0.0",
     "rollup": "^4.24.0",
     "rollup-plugin-dts": "^6.1.1",
+    "tailwindcss": "^4.0.6",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.22.0",
-    "ws": "^8.18.1"
+    "typescript-eslint": "^8.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "dependencies": {
     "@google/genai": "^0.2.0",
-    "blob-polyfill": "^9.0.20240710",
-    "ws": "^8.18.0"
+    "blob-polyfill": "^9.0.20240710"
   },
   "devDependencies": {
     "@material/web": "^2.2.0",
@@ -36,7 +35,7 @@
     "@types/node": "^22.7.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
-    "@types/tailwindcss": "^3.0.11",
+    "@types/ws": "^8.18.1",
     "concurrently": "^9.0.1",
     "esbuild": ">=0.25.0",
     "eslint": "^9.19.0",
@@ -49,8 +48,8 @@
     "react-dom": "^19.0.0",
     "rollup": "^4.24.0",
     "rollup-plugin-dts": "^6.1.1",
-    "tailwindcss": "^4.0.6",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.22.0"
+    "typescript-eslint": "^8.22.0",
+    "ws": "^8.18.1"
   }
 }


### PR DESCRIPTION
Introduce abstractions for network transport such that library users may provide their own implementation if they do not want (or are unable) to use websockets. Add tests for actions/evergreen/run.ts