### PR TITLE
Export stream module in root index

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,3 +10,4 @@ export * as sessions from './sessions/index.js';
 export * as actions from './actions/index.js';
 export * as async from './async/index.js';
 export * as base64 from './base64/index.js';
+export * as stream from './stream/index.js';


### PR DESCRIPTION
Lets users import and use stream utilities, like the `Stream` interface and the `createStream` function.